### PR TITLE
use the scaled coordinates from motile_toolbox 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies =[
     "qtpy",
     "scikit-image",
     "motile >= 0.3",
-    "motile_toolbox >=0.3.3",
+    "motile_toolbox >=0.3.4",
     "pydantic",
     "tifffile[all]",
     "fonticon-fontawesome6",

--- a/src/motile_plugin/layers/track_graph.py
+++ b/src/motile_plugin/layers/track_graph.py
@@ -19,7 +19,6 @@ class TrackGraph(napari.layers.Tracks):
         tracks: Tracks,
         name: str,
         colormap: CyclicLabelColormap,
-        scale: tuple,
     ):
         if tracks is None or tracks.graph is None:
             graph = nx.DiGraph()
@@ -37,15 +36,12 @@ class TrackGraph(napari.layers.Tracks):
             name=name,
             tail_length=3,
             color_by="track_id",
-            scale=scale,
         )
 
         self.viewer = viewer
         self.colormaps_dict["track_id"] = colormap
 
-        self.tracks_layer_graph = copy.deepcopy(
-            self.graph
-        )  # for restoring graph later
+        self.tracks_layer_graph = copy.deepcopy(self.graph)  # for restoring graph later
 
     def update_track_visibility(self, visible: list[int] | str) -> None:
         """Optionally show only the tracks of a current lineage"""

--- a/src/motile_plugin/layers/track_points.py
+++ b/src/motile_plugin/layers/track_points.py
@@ -17,21 +17,20 @@ class TrackPoints(napari.layers.Points):
         selected_nodes: NodeSelectionList,
         symbolmap: dict[NodeType, str],
         colormap: napari.utils.Colormap,
-        scale: tuple,
     ):
         self.colormap = colormap
         self.symbolmap = symbolmap
 
         self.nodes = list(tracks.graph.nodes)
         self.node_index_dict = dict(
-            zip(self.nodes, [self.nodes.index(node) for node in self.nodes])
+            zip(
+                self.nodes,
+                [self.nodes.index(node) for node in self.nodes],
+                strict=False,
+            )
         )
-        points = [
-            tracks.get_location(node, incl_time=True) for node in self.nodes
-        ]
-        track_ids = [
-            tracks.graph.nodes[node]["tracklet_id"] for node in self.nodes
-        ]
+        points = [tracks.get_location(node, incl_time=True) for node in self.nodes]
+        track_ids = [tracks.graph.nodes[node]["tracklet_id"] for node in self.nodes]
         colors = [colormap.map(track_id) for track_id in track_ids]
         symbols = self.get_symbols(tracks, symbolmap)
 
@@ -43,7 +42,6 @@ class TrackPoints(napari.layers.Points):
             size=5,
             properties={"node_id": self.nodes, "track_id": track_ids},
             border_color=[1, 1, 1, 1],
-            scale=scale,
         )
 
         self.viewer = viewer
@@ -76,18 +74,13 @@ class TrackPoints(napari.layers.Points):
             node_id = self.nodes[point]
             self.selected_nodes.add(node_id, True)
 
-    def get_symbols(
-        self, tracks: Tracks, symbolmap: dict[NodeType, str]
-    ) -> list[str]:
+    def get_symbols(self, tracks: Tracks, symbolmap: dict[NodeType, str]) -> list[str]:
         statemap = {
             0: NodeType.END,
             1: NodeType.CONTINUE,
             2: NodeType.SPLIT,
         }
-        symbols = [
-            symbolmap[statemap[degree]]
-            for _, degree in tracks.graph.out_degree
-        ]
+        symbols = [symbolmap[statemap[degree]] for _, degree in tracks.graph.out_degree]
         return symbols
 
     def update_point_outline(self, visible: list[int] | str) -> None:

--- a/src/motile_plugin/widgets/motile/motile_widget.py
+++ b/src/motile_plugin/widgets/motile/motile_widget.py
@@ -131,14 +131,10 @@ class MotileWidget(QScrollArea):
         tracked_masks = np.zeros_like(segmentation, shape=output_shape)
         for node, _data in solution_nx_graph.nodes(data=True):
             time_frame = solution_nx_graph.nodes[node][NodeAttr.TIME.value]
-            previous_seg_id = solution_nx_graph.nodes[node][
-                NodeAttr.SEG_ID.value
-            ]
+            previous_seg_id = solution_nx_graph.nodes[node][NodeAttr.SEG_ID.value]
             tracklet_id = solution_nx_graph.nodes[node]["tracklet_id"]
             if NodeAttr.SEG_HYPO.value in solution_nx_graph.nodes[node]:
-                hypothesis_id = solution_nx_graph.nodes[node][
-                    NodeAttr.SEG_HYPO.value
-                ]
+                hypothesis_id = solution_nx_graph.nodes[node][NodeAttr.SEG_HYPO.value]
             else:
                 hypothesis_id = 0
             previous_seg_mask = (
@@ -172,6 +168,7 @@ class MotileWidget(QScrollArea):
             run.solver_params,
             input_data,
             lambda event_data: self._on_solver_event(run, event_data),
+            scale=run.scale,
         )
         if run.input_segmentation is not None:
             output_segmentation = self.relabel_segmentation(
@@ -196,14 +193,9 @@ class MotileWidget(QScrollArea):
             event_data (dict): The solver event data from ilpy.EventData
         """
         event_type = event_data["event_type"]
-        if (
-            event_type in ["PRESOLVE", "PRESOLVEROUND"]
-            and run.status != "presolving"
-        ):
+        if event_type in ["PRESOLVE", "PRESOLVEROUND"] and run.status != "presolving":
             run.status = "presolving"
-            run.gaps = (
-                []
-            )  # try this to remove the weird initial gap for gurobi
+            run.gaps = []  # try this to remove the weird initial gap for gurobi
             self.solver_update.emit()
         elif event_type in ["MIPSOL", "BESTSOLFOUND"]:
             run.status = "solving"

--- a/src/motile_plugin/widgets/motile/run_viewer.py
+++ b/src/motile_plugin/widgets/motile/run_viewer.py
@@ -224,7 +224,7 @@ class RunViewer(QGroupBox):
         self._set_solver_label(self.run.status)
         self.gap_plot.getPlotItem().clear()
         gaps = self.run.gaps
-        if len(gaps) > 0:
+        if gaps is not None and len(gaps) > 0:
             self.gap_plot.getPlotItem().plot(range(len(gaps)), gaps)
 
     def reset_progress(self):


### PR DESCRIPTION
Scaled coordinates are used for solving and displaying the data. 
What is a little confusing is that the points and tracks layers directly use the scaled (potentially float) coordinates, and therefore should not use the 'scale' attribute anymore (otherwise they are scaled twice). The only layer that needs to be scaled is the labels layer. 
The same scaled coordinates are used for setting the camera center, and since we request the corner_pixels from the points layer we can directly use these values, without rescaling, to check if a node is in view and to set the center. 
